### PR TITLE
Fix responsive article

### DIFF
--- a/src/lib/components/Article.svelte
+++ b/src/lib/components/Article.svelte
@@ -113,5 +113,20 @@
             grid-template-columns: 40% 60%;
         }
     }
+
+    @container --article (width < 230px) {
+        h2 {
+            font-size: var(--sm);
+        }
+
+        button {
+            font-size: 0.7rem;
+        }
+
+        .container img {
+            height: 150px;
+        }
+    }
+
 </style>
 


### PR DESCRIPTION
## What does this change?

Resolves issue #79 

I have removed the introtext and restyled the article a bit to make it look more like the figma design since i wasnt too happy with it yet. Also were gonna change the headings from title to sidetitles but since the client didnt want smaller titles I didnt swap them but since i removed the introtext it looks good anyways. 

[livesite](https://livesite.com)

- [x] [User test]()
- [x] [Accessibility test]()
- [x] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Images
<img width="320" height="424" alt="image" src="https://github.com/user-attachments/assets/0539a577-3af6-486b-b71f-6885579844c5" />

<img width="496" height="236" alt="image" src="https://github.com/user-attachments/assets/e736aae3-12fd-40e5-a9e4-6c884a678f86" />


## How to review
Check if you like the way they look now, and let me now if i can make some other changes if needed. 
