### PR TITLE
Fix add responsive images to article

### DIFF
--- a/src/lib/components/molecules/Article.svelte
+++ b/src/lib/components/molecules/Article.svelte
@@ -5,11 +5,13 @@
 <article data-district="{article.district}">
     <a href="/nieuws/{article.id}">
         <div class="container">
-            <img 
-                src="https://fdnd-agency.directus.app/assets/{article.cover}" 
-                alt="" 
-                width="280" 
-                height="150">
+            <picture>
+                <source 
+                    srcset="https://fdnd-agency.directus.app/assets/{ article.cover }?format=webp&width=500"
+                    media="(min-width: 430px)"
+                    type="image/webp">
+                <img src="https://fdnd-agency.directus.app/assets/{ article.cover }?width=300" alt="">
+            </picture>
 
             <div class="content">   
                 <h2>{ article.title }</h2>
@@ -21,7 +23,6 @@
             </div>
         </div>
     </a>
-    
 </article>
 
 <style>
@@ -62,6 +63,7 @@
                 object-position: center;
                 height: 100%;
                 max-height: 240px;
+                display: block;
             }
 
             .content {
@@ -73,6 +75,7 @@
 
                 h2 {
                     margin-top: 0.5rem;
+                    font-size: clamp(1.3rem, 5vw, 1.8rem);
                 }
 
                 .buttons {
@@ -127,6 +130,5 @@
             height: 150px;
         }
     }
-
 </style>
 


### PR DESCRIPTION
## What does this change?

Resolves issue #68 

I added responsive images to the articles with a picture element and source. The size will now change when the article gets wider.

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] [User test]()
- [x] [Accessibility test]()
- [x] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## How to review

Check the code within the picture element.
