### PR TITLE
feature: nice animation for buttons but calm hover for prefered reduc…

### DIFF
--- a/src/lib/components/molecules/Article.svelte
+++ b/src/lib/components/molecules/Article.svelte
@@ -43,8 +43,6 @@
 
     article { 
         color: var(--secondary-color-general);       
-        background-color: var(--primary-color-general);
-        border-radius: var(--border-radius-md);
 
         container-type: inline-size;
         container-name: --article;
@@ -52,11 +50,13 @@
         a {
             text-decoration: none;
             color: var(--secondary-color-general);
+            background-color: var(--primary-color-general);
+            border: solid 3px var(--secondary-color-general);
             display: flex;
             flex-direction: column;
-            border: solid 3px var(--secondary-color-general);
             border-radius: var(--border-radius-md);
             overflow: hidden;
+            
 
             img {
                 width: 100%;


### PR DESCRIPTION
Prefered reduced motion  #74 

## What does this change?

Resolves issue #74 

I added an animation for the district and category buttons. I also added prefered-reduced-motion mediaquerie so that if you have your animations turned off you will only get a calm hover effect which changes only the colors of the buttons slowly. 

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] [User test]()
- [x] [Accessibility test]()
- [x] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Video's

Without preference:

https://github.com/user-attachments/assets/a985c0b1-4642-47ec-bfba-90597be50947

With preference: 

https://github.com/user-attachments/assets/b328315f-4c9f-4932-a331-c8901a9c62ed


## How to review

Check the animation yourself or check if you maybe see any double code for the 2 buttons.
