### PR TITLE
Feature add container query to newsletter

### DIFF
--- a/src/lib/components/atoms/Newsletter.svelte
+++ b/src/lib/components/atoms/Newsletter.svelte
@@ -15,20 +15,25 @@
 
 <style>
     form {
+        display: flex;
+        justify-content: center;
+        width: 100%;
+        
         container-type: inline-size;
         container-name: --newsletter;
-        
-        width: 265px;
     }
 
     div {
-        display: flex;
-        flex-direction: column;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        justify-content: center;
+        align-items: center;
 
         label {
             color: white;
             font-size: var(--sm);
             padding-bottom: var(--xs);
+            grid-column: span 2;
         }
 
         button {
@@ -41,9 +46,9 @@
             color: white;
             background-color: var(--accent-color);
             border: none;
-            padding-right: 35px;
-            padding-left: 10px;
             height: 1.5rem;
+            padding-inline: var(--xs);
+            grid-column: 2;
 
             &:hover {
                 background-color: var(--accent-color-darker);
@@ -56,8 +61,9 @@
         border-style: solid;
         border-color: #CACACA;
         border-width: 1px 1px 1px 1px; 
-        grid-row: 2;
+        grid-column: span 2;
         height: 1.5rem;
+        width: 100%;
     }
 
     input::placeholder {
@@ -66,7 +72,7 @@
         font-size: 0.7rem;
     }
 
-    @container --newsletter (width > 264px) { 
+    @container --newsletter (width > 220px) { 
 
         div {
             display: grid;
@@ -81,9 +87,12 @@
             button {
                 grid-row: 2;
                 grid-column: 2;
+                padding-right: 35px;
+                padding-left: 10px;
             }
 
             input {
+                grid-column: 1;
                 border-width: 1px 0 1px 1px; 
             }
 

--- a/src/lib/components/organisms/Footer.svelte
+++ b/src/lib/components/organisms/Footer.svelte
@@ -75,6 +75,7 @@
                 gap: var(--md);
                 align-items: center;
                 justify-content: center;
+                min-width: 16rem;
 
                 .socials {
                     padding: 0;


### PR DESCRIPTION
## What does this change?

Resolves issue #125 

I added container queries to the newsletter. Now the styling is completely different so before 220px width of the container it will have a different styling and then after it will have the styling it used to have with the flag on the side as well. 
[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [x] [Accessibility test]()
- [x] [Performance test]()
- [ ] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Images

https://github.com/user-attachments/assets/14416740-88e3-49f0-a478-b88621c66aac

## How to review

Check if you like the new layout for when the newsletter is smaller. Also maybe I might have double code, im not sure. Could you check if this is the case?
