### PR TITLE
fix: fixed the "alles" filter with an if/else statement #165  #151

### DIFF
--- a/src/lib/components/atoms/FilterButtons.svelte
+++ b/src/lib/components/atoms/FilterButtons.svelte
@@ -1,6 +1,12 @@
 <script>
     import { Article } from '$lib';
+    import { page } from '$app/state';
+    
     let {data} = $props();
+
+    const activeFilter = $derived(
+        page.url.searchParams.get('filter')
+    );
 </script>
 
 <section>
@@ -13,7 +19,14 @@
     </ul>
 
     <h2>Buurtcampus // {data.data[0].district}</h2>
-    <p>Alle artikelen met het filter '{data.data[0].categories[0].buurtcampuskrant_categories_id.title}'</p>
+    <p>
+        Alle artikelen met het filter
+        {#if !activeFilter}
+            'alles'
+        {:else}
+            '{data.data[0].categories[0].buurtcampuskrant_categories_id.title}'
+        {/if}
+    </p>
 </section>
 
 <style>


### PR DESCRIPTION
## What does this change?
I added a const to check if there is an url parameter. If there isn't one the filter will show "alles" else the filter will show the category of the first article still. 

Resolves issue #151 

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [x] [Accessibility test]()
- [x] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Images
<img width="1915" height="914" alt="image" src="https://github.com/user-attachments/assets/f4d0a83c-e569-4602-a393-111b516e658e" />

## How to review

Check if you see any mistakes on there still maybe after clicking multiple buttons it might not work as good anymore but I think it will work perfectly. 
