### PR TITLE
fix: removed the 0.7rem font size on button #162

### DIFF
--- a/src/lib/components/molecules/Article.svelte
+++ b/src/lib/components/molecules/Article.svelte
@@ -147,10 +147,6 @@
             font-size: var(--sm);
         }
 
-        button {
-            font-size: 0.7rem;
-        }
-
         .container img {
             height: 150px;
         }


### PR DESCRIPTION
## What does this change?
Only removed the font-size change to 0.7rem. Now the font-size will be minimal of 1rem always. 

Resolves issue #162 

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images


## How to review
Its just a small fix you can accept or check it for a second. 
