### PR TITLE
Fix large screen newsletter

### DIFF
--- a/src/lib/components/atoms/Newsletter.svelte
+++ b/src/lib/components/atoms/Newsletter.svelte
@@ -22,7 +22,8 @@
         display: grid;
         grid-template-columns: 2fr 1fr;
         grid-template-rows: 1fr 1fr;
-        width: 14.375rem;
+        width: 100%;
+        max-width: 20rem;
         row-gap: var(--xs);
 
         button {
@@ -30,7 +31,7 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            font-size: 0.7rem;
+            font-size: 1rem;
             grid-row: 2;
             font-weight: 500;
             color: white;
@@ -69,7 +70,32 @@
         input::placeholder {
             color: #CACACA;
             font-style: italic;
-            font-size: 0.7rem;
+            font-size: 1rem;
         }
     }
+
+    @media (min-width: 1024px) {
+
+        form {
+            max-width: 25rem;
+        }
+
+        form label {
+            font-size: 1.5rem;
+        }
+        
+        form input, form button {
+            height: 2rem; 
+        }
+
+        form input::placeholder, form button {
+            font-size: 1.2rem; 
+        }
+
+        form button::after {
+            border-top: 16px solid transparent;
+            border-bottom: 16px solid transparent;
+            border-right: 20px solid var(--primary-color-general);
+        }
+    }  
 </style>


### PR DESCRIPTION
## What does this change?
Added a mediaquerie to make the newsletter bigger on larger screens. I tested it with 1920px which is a very big screen and it now looks better. 

Resolves issue #155 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [x] [Accessibility test]()
- [x] [Performance test]()
- [ ] [Responsive Design test]()
- [x] [Device test]()
- [ ] [Browser test]()

## Images

<img width="1919" height="926" alt="image" src="https://github.com/user-attachments/assets/c617dcb2-705a-4424-af61-751f1169fe8c" />


## How to review

Check if you think this is big enough if not let me know i can change the code again.
