### PR TITLE
fix: semantic html fixes and some styling to fix #177

### DIFF
--- a/src/lib/components/molecules/FullArticle.svelte
+++ b/src/lib/components/molecules/FullArticle.svelte
@@ -8,11 +8,13 @@
     <ProgressBar/>
 
     <article class="article-detail">
-        <p class="label-district">{article.district}</p>
-        <p class="label-category">{article.category}</p>
-        <h2 class="title">{article.title}</h2>
+        <div class="semantic-flex">
+            <h2 class="title">{article.title}</h2>
+            <p class="label-district">{article.district}</p>
+        </div>
+
         <p class="intro">{article.intro}</p>
-        <p class="side-title">{article.side_title}</p>
+        <span aria-hidden="true" class="side-title">{article.side_title}</span>
         <img class="cover"
             src="https://fdnd-agency.directus.app/assets/{article.cover}"
             alt="{article.alt}" />
@@ -20,6 +22,7 @@
         <div class="body">{@html article.body}</div>
     </article>
 </div>
+
 <style>
     .flex-progress {
         display: flex;
@@ -28,50 +31,56 @@
     }
 
     article {
-            padding: var(--sm);
-            background-color: var(--primary-color-general);
-            border-radius: var(--border-radius-sm);
-            height: 100%;
-            width: 90vw;
-            justify-items: center;
+        padding: var(--sm);
+        background-color: var(--primary-color-general);
+        border-radius: var(--border-radius-sm);
+        height: 100%;
+        width: 90vw;
 
-            img {
-                width: 100%;
-                margin: 1rem 0 1rem 0;
-                float: right;
-
-                @media(min-width:650px) {
-                    height: 40vh;
-                }
-
-                @media(min-width:800px) {
-                    width: 25vw;
-                    margin: 1rem 2rem 2rem 2rem;
-                }
-            }
+        .semantic-flex {
+            display: flex;
+            flex-direction: column;
+            padding-top: 1.5rem;
 
             h2 {
                 max-width: 30rem;
             }
 
-            h2, .side-title, p, div {
-                color: var(--secondary-color-general);
-            }
-
             .label-district {
                 color: var(--primary-color-general);
+                order: -1;
             }
-        } 
-        
-        @media (width > 1020px) {
-            article {
-                width: 65vw;
+        }
+            
+        img {
+            width: 100%;
+            margin: 1rem 0 1rem 0;
+            float: right;
+
+            @media(min-width:650px) {
+                height: 40vh;
+            }
+
+            @media(min-width:800px) {
+                width: 25vw;
+                margin: 1rem 2rem 2rem 2rem;
             }
         }
 
-        @media (width > 1680px) {
-            article {
-                font-size: 1.2rem;
-            }
+        h2, .side-title, p, div {
+            color: var(--secondary-color-general);
         }
+    } 
+        
+    @media (width > 1020px) {
+        article {
+            width: 65vw;
+        }
+    }
+
+    @media (width > 1680px) {
+        article {
+            font-size: 1.2rem;
+        }
+    }
 </style>


### PR DESCRIPTION
## What does this change?

Resolves issue #177 

fixed the semantic of the html so that the H2 is now the first one to be read by a screenreader and the sidetitle wont be read because it is the same text as the h2 so that would be double reading. 

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [x] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review
Check if i missed anything. 
